### PR TITLE
fix name

### DIFF
--- a/StatementOfPurpose.md
+++ b/StatementOfPurpose.md
@@ -1,7 +1,7 @@
 ------------------------
-# UV Coders
+# UV Codebase
 -----------------------------------
-##Briefly - What is UV Coder ?
+##Briefly - What is UV Codebase ?
 
 It's a group gathering around the common purpose of coding (or programming), possibly related to a free software project. There is a focus on sharing tips and tricks, learning by doing, and contributing to the free software community.
 


### PR DESCRIPTION
Changing "UV Coders" -> "UV Codebase": was UV Coders an old name?  :)
